### PR TITLE
fix ConcurrentModificationException during unsubscription

### DIFF
--- a/src/main/kotlin/org/rekotlin/Store.kt
+++ b/src/main/kotlin/org/rekotlin/Store.kt
@@ -54,7 +54,7 @@ class Store<State: StateType> (
                 middleware(dispatch, getState)(dispatchFunction)
             })
 
-    val subscriptions: MutableList<SubscriptionBox<State, Any>> = mutableListOf()
+    val subscriptions: MutableList<SubscriptionBox<State, Any>> = arrayListOf()
 
     private var isDispatching = false
 

--- a/src/test/kotlin/org/rekotlin/StoreSubscriptionTests.kt
+++ b/src/test/kotlin/org/rekotlin/StoreSubscriptionTests.kt
@@ -209,4 +209,33 @@ internal class StoreSubscriptionTests {
         store.unsubscribe(blockSubscriptions)
         assertEquals(0, store.subscriptions.count())
     }
+
+    @Test
+    fun testSubscribeDuringOnNewState() {
+        // setup
+        val reducer = TestValueStringReducer()
+        val store = Store(reducer = reducer::handleAction, state = TestStringAppState())
+
+        val subscribeA = ViewSubscriberTypeA(store)
+        store.subscribe(subscribeA)
+
+        // execute
+        store.dispatch(SetValueStringAction("subscribe"))
+    }
+
+    @Test
+    fun testUnSubscribeDuringOnNewState() {
+        // setup
+        val reducer = TestValueStringReducer()
+        val store = Store(reducer = reducer::handleAction, state = TestStringAppState())
+
+        val subscriberA = ViewSubscriberTypeA(store)
+        val subscriberC = ViewSubscriberTypeC()
+        store.subscribe(subscriberA)
+        store.subscribe(subscriberC)
+
+        // execute
+        store.dispatch(SetValueStringAction("unsubscribe"))
+    }
+
 }

--- a/src/test/kotlin/org/rekotlin/TestFakes.kt
+++ b/src/test/kotlin/org/rekotlin/TestFakes.kt
@@ -114,6 +114,38 @@ internal class TestStoreSubscriber<T> : StoreSubscriber<T> {
     }
 }
 
+/**
+ * A subscriber contains another sub-subscribers [StoreSubscriber], which could be subscribe/unsubscribe at some point
+ */
+internal class ViewSubscriberTypeA(var store: Store<TestStringAppState>) : StoreSubscriber<TestStringAppState> {
+    private val viewB by lazy { ViewSubscriberTypeB(store) }
+    private val viewC by lazy { ViewSubscriberTypeC() }
+
+    override fun newState(state: TestStringAppState) {
+        when(state.testValue){
+            "subscribe" -> store.subscribe(viewC)
+            "unsubscribe" ->  store.unsubscribe(viewB)
+            else -> println(state.testValue)
+        }
+    }
+}
+
+internal class ViewSubscriberTypeB(store: Store<TestStringAppState>) : StoreSubscriber<TestStringAppState> {
+    init {
+        store.subscribe(this)
+    }
+
+    override fun newState(state: TestStringAppState) {
+        // do nothing
+    }
+}
+
+internal class ViewSubscriberTypeC : StoreSubscriber<TestStringAppState> {
+    override fun newState(state: TestStringAppState) {
+        // do nothing
+    }
+}
+
 internal class DispatchingSubscriber(var store: Store<TestAppState>) : StoreSubscriber<TestAppState> {
 
     override fun newState(state: TestAppState) {


### PR DESCRIPTION
fix java.util.ConcurrentModificationException on the subscriptions object, which may occur when dispatch an action while unsubscribe some StoreSubscribers