### PR TITLE
Add `CompositeStore`

### DIFF
--- a/rekotlin/src/main/kotlin/org/rekotlin/Compose.kt
+++ b/rekotlin/src/main/kotlin/org/rekotlin/Compose.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNCHECKED_CAST", "unused")
+@file:Suppress("UNCHECKED_CAST", "unused", "NOTHING_TO_INLINE")
 
 package org.rekotlin
 
@@ -121,12 +121,12 @@ inline fun <S1, S2, S3, S4, S5, S6, S7, S8, S9, State> composeStores(
     compose(it.s1(), it.s2(), it.s3(), it.s4(), it.s5(), it.s6(), it.s7(), it.s8(), it.s9())
 }
 
-fun <S> Array<out Store<*>>.s1() = this[0].state as S
-fun <S> Array<out Store<*>>.s2() = this[1].state as S
-fun <S> Array<out Store<*>>.s3() = this[2].state as S
-fun <S> Array<out Store<*>>.s4() = this[3].state as S
-fun <S> Array<out Store<*>>.s5() = this[4].state as S
-fun <S> Array<out Store<*>>.s6() = this[5].state as S
-fun <S> Array<out Store<*>>.s7() = this[6].state as S
-fun <S> Array<out Store<*>>.s8() = this[7].state as S
-fun <S> Array<out Store<*>>.s9() = this[8].state as S
+@PublishedApi internal inline fun <S> Array<out Store<*>>.s1() = this[0].state as S
+@PublishedApi internal inline fun <S> Array<out Store<*>>.s2() = this[1].state as S
+@PublishedApi internal inline fun <S> Array<out Store<*>>.s3() = this[2].state as S
+@PublishedApi internal inline fun <S> Array<out Store<*>>.s4() = this[3].state as S
+@PublishedApi internal inline fun <S> Array<out Store<*>>.s5() = this[4].state as S
+@PublishedApi internal inline fun <S> Array<out Store<*>>.s6() = this[5].state as S
+@PublishedApi internal inline fun <S> Array<out Store<*>>.s7() = this[6].state as S
+@PublishedApi internal inline fun <S> Array<out Store<*>>.s8() = this[7].state as S
+@PublishedApi internal inline fun <S> Array<out Store<*>>.s9() = this[8].state as S

--- a/rekotlin/src/main/kotlin/org/rekotlin/Compose.kt
+++ b/rekotlin/src/main/kotlin/org/rekotlin/Compose.kt
@@ -1,0 +1,132 @@
+@file:Suppress("UNCHECKED_CAST", "unused")
+
+package org.rekotlin
+
+typealias Compose<State> = (Array<out Store<*>>) -> State
+typealias Compose1<S1, State> = (S1) -> State
+typealias Compose2<S1, S2, State> = (S1, S2) -> State
+typealias Compose3<S1, S2, S3, State> = (S1, S2, S3) -> State
+typealias Compose4<S1, S2, S3, S4, State> = (S1, S2, S3, S4) -> State
+typealias Compose5<S1, S2, S3, S4, S5, State> = (S1, S2, S3, S4, S5) -> State
+typealias Compose6<S1, S2, S3, S4, S5, S6, State> = (S1, S2, S3, S4, S5, S6) -> State
+typealias Compose7<S1, S2, S3, S4, S5, S6, S7, State> = (S1, S2, S3, S4, S5, S6, S7) -> State
+typealias Compose8<S1, S2, S3, S4, S5, S6, S7, S8, State> = (S1, S2, S3, S4, S5, S6, S7, S8) -> State
+typealias Compose9<S1, S2, S3, S4, S5, S6, S7, S8, S9, State> = (S1, S2, S3, S4, S5, S6, S7, S8, S9) -> State
+
+inline fun <S1, State> composeStores(
+    store1: Store<S1>,
+    vararg middleware: Middleware<State>,
+    crossinline compose: Compose1<S1, State> = { it as State }
+): Store<State> = CompositeStore(store1, middleware = middleware.toList()) {
+    compose(it.s1())
+}
+
+inline fun <S1, S2, State> composeStores(
+    store1: Store<S1>,
+    store2: Store<S2>,
+    vararg middleware: Middleware<State>,
+    crossinline compose: Compose2<S1, S2, State>
+): Store<State> = CompositeStore(store1, store2, middleware = middleware.toList()) {
+    compose(it.s1(), it.s2())
+}
+
+inline fun <S1, S2, S3, State> composeStores(
+    store1: Store<S1>,
+    store2: Store<S2>,
+    store3: Store<S3>,
+    vararg middleware: Middleware<State>,
+    crossinline compose: Compose3<S1, S2, S3, State>
+): Store<State> = CompositeStore(store1, store2, store3, middleware = middleware.toList()) {
+    compose(it.s1(), it.s2(), it.s3())
+}
+
+inline fun <S1, S2, S3, S4, State> composeStores(
+    store1: Store<S1>,
+    store2: Store<S2>,
+    store3: Store<S3>,
+    store4: Store<S4>,
+    vararg middleware: Middleware<State>,
+    crossinline compose: Compose4<S1, S2, S3, S4, State>
+): Store<State> = CompositeStore(store1, store2, store3, store4, middleware = middleware.toList()) {
+    compose(it.s1(), it.s2(), it.s3(), it.s4())
+}
+
+inline fun <S1, S2, S3, S4, S5, State> composeStores(
+    store1: Store<S1>,
+    store2: Store<S2>,
+    store3: Store<S3>,
+    store4: Store<S4>,
+    store5: Store<S5>,
+    vararg middleware: Middleware<State>,
+    crossinline compose: Compose5<S1, S2, S3, S4, S5, State>
+): Store<State> = CompositeStore(store1, store2, store3, store4, store5, middleware = middleware.toList()) {
+    compose(it.s1(), it.s2(), it.s3(), it.s4(), it.s5())
+}
+
+inline fun <S1, S2, S3, S4, S5, S6, State> composeStores(
+    store1: Store<S1>,
+    store2: Store<S2>,
+    store3: Store<S3>,
+    store4: Store<S4>,
+    store5: Store<S5>,
+    store6: Store<S6>,
+    vararg middleware: Middleware<State>,
+    crossinline compose: Compose6<S1, S2, S3, S4, S5, S6, State>
+): Store<State> = CompositeStore(store1, store2, store3, store4, store5, store6, middleware = middleware.toList()) {
+    compose(it.s1(), it.s2(), it.s3(), it.s4(), it.s5(), it.s6())
+}
+
+inline fun <S1, S2, S3, S4, S5, S6, S7, State> composeStores(
+    store1: Store<S1>,
+    store2: Store<S2>,
+    store3: Store<S3>,
+    store4: Store<S4>,
+    store5: Store<S5>,
+    store6: Store<S6>,
+    store7: Store<S7>,
+    vararg middleware: Middleware<State>,
+    crossinline compose: Compose7<S1, S2, S3, S4, S5, S6, S7, State>
+): Store<State> = CompositeStore(store1, store2, store3, store4, store5, store6, store7, middleware = middleware.toList()) {
+    compose(it.s1(), it.s2(), it.s3(), it.s4(), it.s5(), it.s6(), it.s7())
+}
+
+inline fun <S1, S2, S3, S4, S5, S6, S7, S8, State> composeStores(
+    store1: Store<S1>,
+    store2: Store<S2>,
+    store3: Store<S3>,
+    store4: Store<S4>,
+    store5: Store<S5>,
+    store6: Store<S6>,
+    store7: Store<S7>,
+    store8: Store<S8>,
+    vararg middleware: Middleware<State>,
+    crossinline compose: Compose8<S1, S2, S3, S4, S5, S6, S7, S8, State>
+): Store<State> = CompositeStore(store1, store2, store3, store4, store5, store6, store7, store8, middleware = middleware.toList()) {
+    compose(it.s1(), it.s2(), it.s3(), it.s4(), it.s5(), it.s6(), it.s7(), it.s8())
+}
+
+inline fun <S1, S2, S3, S4, S5, S6, S7, S8, S9, State> composeStores(
+    store1: Store<S1>,
+    store2: Store<S2>,
+    store3: Store<S3>,
+    store4: Store<S4>,
+    store5: Store<S5>,
+    store6: Store<S6>,
+    store7: Store<S7>,
+    store8: Store<S8>,
+    store9: Store<S9>,
+    vararg middleware: Middleware<State>,
+    crossinline compose: Compose9<S1, S2, S3, S4, S5, S6, S7, S8, S9, State>
+): Store<State> = CompositeStore(store1, store2, store3, store4, store5, store6, store7, store8, store9, middleware = middleware.toList()) {
+    compose(it.s1(), it.s2(), it.s3(), it.s4(), it.s5(), it.s6(), it.s7(), it.s8(), it.s9())
+}
+
+fun <S> Array<out Store<*>>.s1() = this[0].state as S
+fun <S> Array<out Store<*>>.s2() = this[1].state as S
+fun <S> Array<out Store<*>>.s3() = this[2].state as S
+fun <S> Array<out Store<*>>.s4() = this[3].state as S
+fun <S> Array<out Store<*>>.s5() = this[4].state as S
+fun <S> Array<out Store<*>>.s6() = this[5].state as S
+fun <S> Array<out Store<*>>.s7() = this[6].state as S
+fun <S> Array<out Store<*>>.s8() = this[7].state as S
+fun <S> Array<out Store<*>>.s9() = this[8].state as S

--- a/rekotlin/src/main/kotlin/org/rekotlin/Compose.kt
+++ b/rekotlin/src/main/kotlin/org/rekotlin/Compose.kt
@@ -2,22 +2,22 @@
 
 package org.rekotlin
 
-typealias Compose<State> = (Array<out Store<*>>) -> State
-typealias Compose1<S1, State> = (S1) -> State
-typealias Compose2<S1, S2, State> = (S1, S2) -> State
-typealias Compose3<S1, S2, S3, State> = (S1, S2, S3) -> State
-typealias Compose4<S1, S2, S3, S4, State> = (S1, S2, S3, S4) -> State
-typealias Compose5<S1, S2, S3, S4, S5, State> = (S1, S2, S3, S4, S5) -> State
-typealias Compose6<S1, S2, S3, S4, S5, S6, State> = (S1, S2, S3, S4, S5, S6) -> State
-typealias Compose7<S1, S2, S3, S4, S5, S6, S7, State> = (S1, S2, S3, S4, S5, S6, S7) -> State
-typealias Compose8<S1, S2, S3, S4, S5, S6, S7, S8, State> = (S1, S2, S3, S4, S5, S6, S7, S8) -> State
-typealias Compose9<S1, S2, S3, S4, S5, S6, S7, S8, S9, State> = (S1, S2, S3, S4, S5, S6, S7, S8, S9) -> State
+internal typealias Compose<State> = (Array<out Store<*>>) -> State
+internal typealias Compose1<S1, State> = (S1) -> State
+internal typealias Compose2<S1, S2, State> = (S1, S2) -> State
+internal typealias Compose3<S1, S2, S3, State> = (S1, S2, S3) -> State
+internal typealias Compose4<S1, S2, S3, S4, State> = (S1, S2, S3, S4) -> State
+internal typealias Compose5<S1, S2, S3, S4, S5, State> = (S1, S2, S3, S4, S5) -> State
+internal typealias Compose6<S1, S2, S3, S4, S5, S6, State> = (S1, S2, S3, S4, S5, S6) -> State
+internal typealias Compose7<S1, S2, S3, S4, S5, S6, S7, State> = (S1, S2, S3, S4, S5, S6, S7) -> State
+internal typealias Compose8<S1, S2, S3, S4, S5, S6, S7, S8, State> = (S1, S2, S3, S4, S5, S6, S7, S8) -> State
+internal typealias Compose9<S1, S2, S3, S4, S5, S6, S7, S8, S9, State> = (S1, S2, S3, S4, S5, S6, S7, S8, S9) -> State
 
 inline fun <S1, State> composeStores(
     store1: Store<S1>,
     vararg middleware: Middleware<State>,
     crossinline compose: Compose1<S1, State> = { it as State }
-): Store<State> = CompositeStore(store1, middleware = middleware.toList()) {
+): Store<State> = compositeStore(store1, middleware = middleware.toList()) {
     compose(it.s1())
 }
 
@@ -26,7 +26,7 @@ inline fun <S1, S2, State> composeStores(
     store2: Store<S2>,
     vararg middleware: Middleware<State>,
     crossinline compose: Compose2<S1, S2, State>
-): Store<State> = CompositeStore(store1, store2, middleware = middleware.toList()) {
+): Store<State> = compositeStore(store1, store2, middleware = middleware.toList()) {
     compose(it.s1(), it.s2())
 }
 
@@ -36,7 +36,7 @@ inline fun <S1, S2, S3, State> composeStores(
     store3: Store<S3>,
     vararg middleware: Middleware<State>,
     crossinline compose: Compose3<S1, S2, S3, State>
-): Store<State> = CompositeStore(store1, store2, store3, middleware = middleware.toList()) {
+): Store<State> = compositeStore(store1, store2, store3, middleware = middleware.toList()) {
     compose(it.s1(), it.s2(), it.s3())
 }
 
@@ -47,7 +47,7 @@ inline fun <S1, S2, S3, S4, State> composeStores(
     store4: Store<S4>,
     vararg middleware: Middleware<State>,
     crossinline compose: Compose4<S1, S2, S3, S4, State>
-): Store<State> = CompositeStore(store1, store2, store3, store4, middleware = middleware.toList()) {
+): Store<State> = compositeStore(store1, store2, store3, store4, middleware = middleware.toList()) {
     compose(it.s1(), it.s2(), it.s3(), it.s4())
 }
 
@@ -59,7 +59,7 @@ inline fun <S1, S2, S3, S4, S5, State> composeStores(
     store5: Store<S5>,
     vararg middleware: Middleware<State>,
     crossinline compose: Compose5<S1, S2, S3, S4, S5, State>
-): Store<State> = CompositeStore(store1, store2, store3, store4, store5, middleware = middleware.toList()) {
+): Store<State> = compositeStore(store1, store2, store3, store4, store5, middleware = middleware.toList()) {
     compose(it.s1(), it.s2(), it.s3(), it.s4(), it.s5())
 }
 
@@ -72,7 +72,7 @@ inline fun <S1, S2, S3, S4, S5, S6, State> composeStores(
     store6: Store<S6>,
     vararg middleware: Middleware<State>,
     crossinline compose: Compose6<S1, S2, S3, S4, S5, S6, State>
-): Store<State> = CompositeStore(store1, store2, store3, store4, store5, store6, middleware = middleware.toList()) {
+): Store<State> = compositeStore(store1, store2, store3, store4, store5, store6, middleware = middleware.toList()) {
     compose(it.s1(), it.s2(), it.s3(), it.s4(), it.s5(), it.s6())
 }
 
@@ -86,7 +86,7 @@ inline fun <S1, S2, S3, S4, S5, S6, S7, State> composeStores(
     store7: Store<S7>,
     vararg middleware: Middleware<State>,
     crossinline compose: Compose7<S1, S2, S3, S4, S5, S6, S7, State>
-): Store<State> = CompositeStore(store1, store2, store3, store4, store5, store6, store7, middleware = middleware.toList()) {
+): Store<State> = compositeStore(store1, store2, store3, store4, store5, store6, store7, middleware = middleware.toList()) {
     compose(it.s1(), it.s2(), it.s3(), it.s4(), it.s5(), it.s6(), it.s7())
 }
 
@@ -101,7 +101,7 @@ inline fun <S1, S2, S3, S4, S5, S6, S7, S8, State> composeStores(
     store8: Store<S8>,
     vararg middleware: Middleware<State>,
     crossinline compose: Compose8<S1, S2, S3, S4, S5, S6, S7, S8, State>
-): Store<State> = CompositeStore(store1, store2, store3, store4, store5, store6, store7, store8, middleware = middleware.toList()) {
+): Store<State> = compositeStore(store1, store2, store3, store4, store5, store6, store7, store8, middleware = middleware.toList()) {
     compose(it.s1(), it.s2(), it.s3(), it.s4(), it.s5(), it.s6(), it.s7(), it.s8())
 }
 
@@ -117,7 +117,7 @@ inline fun <S1, S2, S3, S4, S5, S6, S7, S8, S9, State> composeStores(
     store9: Store<S9>,
     vararg middleware: Middleware<State>,
     crossinline compose: Compose9<S1, S2, S3, S4, S5, S6, S7, S8, S9, State>
-): Store<State> = CompositeStore(store1, store2, store3, store4, store5, store6, store7, store8, store9, middleware = middleware.toList()) {
+): Store<State> = compositeStore(store1, store2, store3, store4, store5, store6, store7, store8, store9, middleware = middleware.toList()) {
     compose(it.s1(), it.s2(), it.s3(), it.s4(), it.s5(), it.s6(), it.s7(), it.s8(), it.s9())
 }
 

--- a/rekotlin/src/main/kotlin/org/rekotlin/CompositeStore.kt
+++ b/rekotlin/src/main/kotlin/org/rekotlin/CompositeStore.kt
@@ -1,0 +1,165 @@
+package org.rekotlin
+
+import java.util.IdentityHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+class CompositeStore<State>(
+    private vararg val stores: Store<*>,
+    middleware: List<Middleware<State>> = emptyList(),
+    private val skipRepeats: Boolean = true,
+    private val compose: Compose<State>
+) : Store<State> {
+
+    private val subscriptions: MutableList<SubscriptionBox<State, *>> = CopyOnWriteArrayList()
+    private val listeners: MutableList<ListenerBox<out Effect>> = CopyOnWriteArrayList()
+    private val middlewares: MutableList<Middleware<State>> = CopyOnWriteArrayList(middleware)
+
+    private val effectDispatcher = EffectDispatcher()
+    private val dispatchEffect: DispatchEffect = { effect ->
+        effectDispatcher.dispatch(effect) {
+            stores.forEach { it.dispatch(effect) }
+            listeners.forEach { it.onEffect(effect) }
+        }
+    }
+
+    private var dispatchAction: DispatchAction = buildDispatchAction()
+
+    init {
+        stores.forEach { store ->
+            store.subscribeTo { _ ->
+                val prevState = _state
+                val newState = compose(stores)
+                _state = newState
+                subscriptions.forEach {
+                    it.newValues(prevState, newState)
+                }
+            }
+            store.listenTo { effect: Effect ->
+                if (!effect.isDispatching) {
+                    listeners.forEach {
+                        it.onEffect(effect)
+                    }
+                }
+            }
+        }
+    }
+
+    private var _state: State? = null
+    override val state: State
+        get() = _state!!
+
+    override fun dispatch(dispatchable: Dispatchable) = dispatchFunction(dispatchable)
+    override val dispatchFunction: DispatchFunction
+        get() = { dispatchable: Dispatchable ->
+            when (dispatchable) {
+                is Effect -> dispatchEffect(dispatchable)
+                is Action -> dispatchAction(dispatchable)
+            }
+        }
+
+    operator fun plusAssign(middleware: Middleware<State>) {
+        middlewares += middleware
+        dispatchAction = buildDispatchAction()
+    }
+
+    operator fun minusAssign(middleware: Middleware<State>) {
+        middlewares -= middleware
+        dispatchAction = buildDispatchAction()
+    }
+
+    private fun buildDispatchAction() =
+        middlewares.reversed()
+            .fold(this::defaultDispatch as DispatchFunction,
+                { dispatch, middleware ->
+                    middleware(this::dispatch, this::state)(dispatch)
+                }
+            )
+
+    private fun defaultDispatch(dispatchable: Dispatchable) =
+        when (dispatchable) {
+            is Dispatcher -> dispatchable.dispatchTo(stores)
+            else -> Dispatcher(dispatchable).dispatchTo(stores)
+        }
+
+    override fun <S : Subscriber<State>> subscribe(subscriber: S) = subscribe(subscriber, { this })
+    override fun <SelectedState, S : Subscriber<SelectedState>> subscribe(
+        subscriber: S,
+        selector: Subscription<State>.() -> Subscription<SelectedState>
+    ) {
+        unsubscribe(subscriber)
+
+        val actualSelector = when {
+            skipRepeats -> compose(selector, Subscription<SelectedState>::skipRepeats)
+            else -> selector
+        }
+
+        val box = SubscriptionBox(actualSelector, subscriber)
+        subscriptions.add(box)
+
+        _state?.let {
+            box.newValues(null, it)
+        }
+    }
+
+    override fun <SelectedState> unsubscribe(subscriber: Subscriber<SelectedState>) {
+        val index = subscriptions.indexOfFirst { it.subscriber === subscriber }
+        if (index != -1) {
+            subscriptions.removeAt(index)
+        }
+    }
+
+    override fun subscribe(listener: Listener<Effect>) = subscribe(listener) { it }
+    override fun <E : Effect> subscribe(listener: Listener<E>, selector: (Effect) -> E?) {
+        unsubscribe(listener)
+        listeners.add(ListenerBox(listener, selector))
+    }
+
+    override fun <E : Effect> unsubscribe(listener: Listener<E>) {
+        val index = listeners.indexOfFirst { it.listener === listener }
+        if (index != -1) {
+            listeners.removeAt(index)
+        }
+    }
+
+    private val Effect.isDispatching get() = effectDispatcher.isDispatching(this)
+}
+
+inline fun <State> Store<State>.subscribeTo(crossinline subscriber: (State) -> Unit) =
+    object : Subscriber<State> {
+        override fun newState(state: State) {
+            subscriber(state)
+        }
+    }.also { subscribe(it) }
+
+inline fun <reified EffectType : Effect> SubscribeStore<*>.listenTo(crossinline onEffect: (EffectType) -> Unit) =
+    listener<EffectType> { onEffect(it) }
+        .also { listener -> subscribe(listener) { it as? EffectType } }
+
+private class EffectDispatcher {
+    private val dispatching = mutableListOf<Effect>()
+
+    fun isDispatching(effect: Effect) = dispatching.any { it === effect }
+
+    fun dispatch(effect: Effect, body: () -> Unit) {
+        dispatching += effect
+        body()
+        dispatching -= effect
+    }
+}
+
+private class Dispatcher(private val dispatchable: Dispatchable) : Dispatchable {
+    private val dispatched = IdentityHashMap<Store<*>, Unit>()
+
+    fun dispatchTo(stores: Array<out Store<*>>) {
+        stores.forEach { store ->
+            if (store !in dispatched) {
+                dispatched += store to Unit
+                if (store is CompositeStore<*>) {
+                    store.dispatch(this)
+                } else {
+                    store.dispatch(dispatchable)
+                }
+            }
+        }
+    }
+}

--- a/rekotlin/src/main/kotlin/org/rekotlin/CompositeStore.kt
+++ b/rekotlin/src/main/kotlin/org/rekotlin/CompositeStore.kt
@@ -38,7 +38,7 @@ private class CompositeStore<State>(
 
     init {
         stores.forEach { store ->
-            store.subscribeTo { _ ->
+            store.subscribeProjected { _ ->
                 val prevState = _state
                 val newState = compose(stores)
                 _state = newState
@@ -134,14 +134,10 @@ private class CompositeStore<State>(
     }
 
     private val Effect.isDispatching get() = effectDispatcher.isDispatching(this)
-}
 
-inline fun <State> Store<State>.subscribeTo(crossinline subscriber: (State) -> Unit) =
-    object : Subscriber<State> {
-        override fun newState(state: State) {
-            subscriber(state)
-        }
-    }.also { subscribe(it) }
+    private inline fun <State> Store<State>.subscribeProjected(crossinline subscriber: (State) -> Unit) =
+        subscribe(subscriber { subscriber(it) })
+}
 
 private class EffectDispatcher {
     private val dispatching = mutableListOf<Effect>()

--- a/rekotlin/src/main/kotlin/org/rekotlin/CompositeStore.kt
+++ b/rekotlin/src/main/kotlin/org/rekotlin/CompositeStore.kt
@@ -46,13 +46,13 @@ private class CompositeStore<State>(
                     it.newValues(prevState, newState)
                 }
             }
-            store.listenTo { effect: Effect ->
+            store.subscribe(listener { effect ->
                 if (!effect.isDispatching) {
                     listeners.forEach {
                         it.onEffect(effect)
                     }
                 }
-            }
+            })
         }
     }
 
@@ -142,10 +142,6 @@ inline fun <State> Store<State>.subscribeTo(crossinline subscriber: (State) -> U
             subscriber(state)
         }
     }.also { subscribe(it) }
-
-inline fun <reified EffectType : Effect> SubscribeStore<*>.listenTo(crossinline onEffect: (EffectType) -> Unit) =
-    listener<EffectType> { onEffect(it) }
-        .also { listener -> subscribe(listener) { it as? EffectType } }
 
 private class EffectDispatcher {
     private val dispatching = mutableListOf<Effect>()

--- a/rekotlin/src/main/kotlin/org/rekotlin/CompositeStore.kt
+++ b/rekotlin/src/main/kotlin/org/rekotlin/CompositeStore.kt
@@ -3,7 +3,19 @@ package org.rekotlin
 import java.util.IdentityHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 
-class CompositeStore<State>(
+fun <State> compositeStore(
+    vararg stores: Store<*>,
+    middleware: List<Middleware<State>> = emptyList(),
+    skipRepeats: Boolean = true,
+    compose: Compose<State>
+): Store<State> = CompositeStore(
+    *stores,
+    middleware = middleware,
+    skipRepeats = skipRepeats,
+    compose = compose
+)
+
+private class CompositeStore<State>(
     private vararg val stores: Store<*>,
     middleware: List<Middleware<State>> = emptyList(),
     private val skipRepeats: Boolean = true,

--- a/rekotlin/src/test/kotlin/org/rekotlin/CompositeStoreTests.kt
+++ b/rekotlin/src/test/kotlin/org/rekotlin/CompositeStoreTests.kt
@@ -208,7 +208,7 @@ class CompositeStoreTests {
     )
 
     @Test
-    fun `subscribe with select and unsubscribe`() {
+    fun `should be able to subscribe with select and unsubscribe on composite store`() {
         val subscriber = TestSubscriber<SelectState>()
         compositeStore.subscribe(subscriber) {
             select {
@@ -233,7 +233,7 @@ class CompositeStoreTests {
     }
 
     @Test
-    fun `subscribe with select doesn't send duplicates`() {
+    fun `should not trigger subscriber multiple times when subscribed with select`() {
         val subscriber = TestSubscriber<SelectState>()
         compositeStore.subscribe(subscriber) {
             select {
@@ -256,7 +256,7 @@ class CompositeStoreTests {
 
     // <editor-fold desc="Effects & Actions dispatched to store > composite store">
     @Test
-    fun `effect dispatched to store triggers composite store listener`() {
+    fun `should trigger composite store listener when effect dispatched to store`() {
         val listener = CountingListener<TestEffect>().also { compositeStore.listen(it) }
 
         store1.dispatch(TestEffect)
@@ -265,7 +265,7 @@ class CompositeStoreTests {
     }
 
     @Test
-    fun `action dispatched to store triggers composite store subscriber`() {
+    fun `should trigger composite store subscriber when action dispatched to store`() {
         val subscriber = TestSubscriber<CompositeState>().also { compositeStore.subscribe(it) }
 
         store1.dispatch(SetState1String(value = "test"))
@@ -285,7 +285,7 @@ class CompositeStoreTests {
 
     // <editor-fold desc="Effects & Actions dispatched to composite store > store">
     @Test
-    fun `effect dispatched to composite store triggers store listener`() {
+    fun `should trigger store listener when effect dispatched to composite store`() {
         val listener1 = CountingListener<TestEffect>().also { store1.listen(it) }
 
         compositeStore.dispatch(TestEffect)
@@ -294,7 +294,7 @@ class CompositeStoreTests {
     }
 
     @Test
-    fun `action dispatched to composite store triggers store subscriber`() {
+    fun `should trigger store subscriber when action dispatched to composite store`() {
         val subscriber1 = TestSubscriber<State1>().also { store1.subscribe(it) }
 
         compositeStore.dispatch(SetState1String(value = "test"))
@@ -303,7 +303,7 @@ class CompositeStoreTests {
     }
 
     @Test
-    fun `unrelated action dispatched to composite store does not trigger store subscriber`() {
+    fun `should not trigger store subscriber when unrelated action dispatched to composite store`() {
         val subscriber1 = TestSubscriber<State1>().also { store1.subscribe(it) }
 
         compositeStore.dispatch(SetState2Integer(value = 123))
@@ -314,7 +314,7 @@ class CompositeStoreTests {
 
     // <editor-fold desc="Effects & Actions dispatched to store > store">
     @Test
-    fun `effect dispatched to store does not trigger other store listener`() {
+    fun `should not trigger store2 listener when effect dispatched to store1`() {
         val listener = CountingListener<TestEffect>().also { store2.listen(it) }
 
         store1.dispatch(TestEffect)
@@ -323,7 +323,7 @@ class CompositeStoreTests {
     }
 
     @Test
-    fun `action dispatched to store does not trigger other store subscriber`() {
+    fun `should not trigger store2 subscriber when action dispatched to store1`() {
         val subscriber = TestSubscriber<State2>().also { store2.subscribe(it) }
 
         store1.dispatch(SetState1String(value = "test"))
@@ -332,7 +332,7 @@ class CompositeStoreTests {
     }
 
     @Test
-    fun `unrelated action dispatched to store does not trigger other store subscriber`() {
+    fun `should not trigger store2 subscriber when unrelated action dispatched to store1`() {
         val subscriber = TestSubscriber<State2>().also { store2.subscribe(it) }
 
         store1.dispatch(SetState2Integer(value = 123))
@@ -369,7 +369,7 @@ class CompositeStoreTests {
 
     // <editor-fold desc="composite store (12) > composite store (23)">
     @Test
-    fun `effect dispatched to composite store triggers other composite store listener`() {
+    fun `should trigger other composite store listener when effect dispatched to composite store`() {
         val listener12 = CountingListener<TestEffect>().also { compositeStore12.listen(it) }
 
         compositeStore23.dispatch(TestEffect)
@@ -378,7 +378,7 @@ class CompositeStoreTests {
     }
 
     @Test
-    fun `action dispatched to composite store triggers other composite store subscriber`() {
+    fun `should trigger other composite store subscriber when action dispatched to composite store`() {
         val subscriber12 = TestSubscriber<TestState12>().also { compositeStore12.subscribe(it) }
 
         compositeStore23.dispatch(SetState2Integer(value = 123))
@@ -387,7 +387,7 @@ class CompositeStoreTests {
     }
 
     @Test
-    fun `unrelated action dispatched to composite store does not trigger other composite store subscriber`() {
+    fun `should not trigger other composite store subscriber when unrelated action dispatched to composite store`() {
         val subscriber12 = TestSubscriber<TestState12>().also { compositeStore12.subscribe(it) }
 
         compositeStore23.dispatch(SetState3Boolean(value = true))
@@ -398,7 +398,7 @@ class CompositeStoreTests {
 
     // <editor-fold desc="middleware">
     @Test
-    fun `cross composite store calls middleware once for duplicate stores`() {
+    fun `should only call middleware once when composite store includes duplicate stores from composite stores`() {
         data class TestState23And12(
             val state2: State2,
             val state3: State3,
@@ -427,7 +427,7 @@ class CompositeStoreTests {
     }
 
     @Test
-    fun `cross composite store calls middleware once for duplicate stores2`() {
+    fun `should only call middleware once when many composite store includes multiple duplicate stores`() {
         data class State13(
             val state1: State1,
             val state3: State3
@@ -478,7 +478,7 @@ class CompositeStoreTests {
 
     // <editor-fold desc="thunk middleware">
     @Test
-    fun `thunk dispatched to composite store affects relevant stores`() {
+    fun `should affect relevant stores when thunk dispatched to composite store`() {
         val store3Subscriber = TestSubscriber<State3> {
             println("Got $it")
             if (it.boolean == null) {
@@ -517,7 +517,7 @@ class CompositeStoreTests {
     }
 
     @Test
-    fun `thunk dispatched to composite store then thunk dispatch affects relevant store`() {
+    fun `should update store3 state when composite thunk dispatched to composite store then thunk dispatch`() {
         val store3Subscriber = TestSubscriber<State3> {
             if (it.boolean == null) {
                 store3.dispatch(SetState3Boolean(value = true))
@@ -536,7 +536,7 @@ class CompositeStoreTests {
     }
 
     @Test
-    fun `thunk dispatched to composite store triggers other composite store listener`() {
+    fun `should trigger compositeStore12 subscriber from store2 when thunk23 dispatched to compositeStore23`() {
         val initialValue = compositeStore23.state.state2.integer
         val add = 10
 
@@ -553,7 +553,7 @@ class CompositeStoreTests {
     }
 
     @Test
-    fun `should throw exception when thunk dispatched from wrong store`() {
+    fun `should throw cast exception when thunk23 dispatched from store12`() {
         val store23Thunk = testThunk<TestState23> { _, getState ->
             println("getState=${getState()}")
         }
@@ -564,13 +564,13 @@ class CompositeStoreTests {
     }
 
     @Test
-    fun `should throw exception when thunk dispatched from wrong dispatcher`() {
+    fun `should throw cast exception when thunk23 dispatched from dispatch12`() {
         val store23Thunk = testThunk<TestState23> { _, getState ->
             println("getState23=${getState()}")
         }
-        val store12Thunk = testThunk<TestState12> { dispatch, getState ->
+        val store12Thunk = testThunk<TestState12> { dispatch12, getState ->
             println("getState12=${getState()}")
-            dispatch(store23Thunk)
+            dispatch12(store23Thunk)
         }
 
         assertThrows(ClassCastException::class.java) {

--- a/rekotlin/src/test/kotlin/org/rekotlin/CompositeStoreTests.kt
+++ b/rekotlin/src/test/kotlin/org/rekotlin/CompositeStoreTests.kt
@@ -1,0 +1,615 @@
+package org.rekotlin
+
+import java.util.IdentityHashMap
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+class CompositeStoreTests {
+
+    // State1
+    private data class State1(
+        val string: String = "",
+        val string2: String = ""
+    )
+
+    private fun state1Reducer(action: Action, oldState: State1?): State1 {
+        val state = oldState ?: State1()
+        return when (action) {
+            is SetState1String -> state.copy(string = action.value)
+            is SetState1String2 -> state.copy(string2 = action.value)
+            else -> state
+        }
+    }
+
+    private val state1Middleware = testMiddleware<State1> { action, getState ->
+        println(">> state1Middleware($action, ${getState()})")
+    }
+
+    // State2
+    private data class State2(
+        val integer: Int = 0
+    )
+
+    private fun state2Reducer(action: Action, oldState: State2?): State2 {
+        val state = oldState ?: State2()
+        return when (action) {
+            is SetState2Integer -> state.copy(integer = action.value)
+            else -> state
+        }
+    }
+
+    private val state2Middleware = testMiddleware<State2> { action, getState ->
+        println(">> state2Middleware($action, ${getState()})")
+    }
+
+    // State3
+    private data class State3(
+        val boolean: Boolean? = false
+    )
+
+    private fun state3Reducer(action: Action, oldState: State3?): State3 {
+        val state = oldState ?: State3()
+        return when (action) {
+            is SetState3Boolean -> state.copy(boolean = action.value)
+            else -> state
+        }
+    }
+
+    private val state3Middleware = testMiddleware<State3> { action, getState ->
+        println(">> state3Middleware($action, ${getState()})")
+    }
+
+    // Actions
+    private data class SetState1String(val value: String) : Action
+    private data class SetState1String2(val value: String) : Action
+    private data class SetState2Integer(val value: Int) : Action
+    private data class SetState3Boolean(val value: Boolean?) : Action
+
+    // Stores
+    private val store1 = store(::state1Reducer, State1(), state1Middleware, thunkMiddleware())
+    private val store2 = store(::state2Reducer, State2(), state2Middleware, thunkMiddleware())
+    private val store3 = store(::state3Reducer, State3(), state3Middleware, thunkMiddleware())
+
+    // Composite Store
+    private data class TestState(
+        val state1: State1,
+        val state2: State2,
+        val state3: State3
+    )
+
+    private val testStore = composeStores(store1, store2, store3, thunkMiddleware()) { a, b, c ->
+        TestState(
+            state1 = a,
+            state2 = b,
+            state3 = c
+        )
+    }
+
+    data class SelectState(
+        val string: String,
+        val int: Int,
+        val bool: Boolean?
+    )
+
+    // Composite2 Stores
+
+    private data class TestState12(
+        val state1: State1,
+        val state2: State2
+    )
+
+    private data class TestState23(
+        val state2: State2,
+        val state3: State3
+    )
+
+    private val testStore12 = composeStores(store1, store2, thunkMiddleware()) { a, b ->
+        TestState12(
+            state1 = a,
+            state2 = b
+        )
+    }
+    private val testStore23 = composeStores(store2, store3, thunkMiddleware()) { a, b ->
+        TestState23(
+            state2 = a,
+            state3 = b
+        )
+    }
+
+    @AfterEach
+    fun afterEach() {
+        assert(state1Middleware.duplicateCount == 0) { "state1Middleware.duplicateCount != 0 (${state1Middleware.duplicateCount})\n > ${state1Middleware.duplicates}" }
+        assert(state2Middleware.duplicateCount == 0) { "state2Middleware.duplicateCount != 0 (${state2Middleware.duplicateCount})\n > ${state2Middleware.duplicates}" }
+        assert(state3Middleware.duplicateCount == 0) { "state3Middleware.duplicateCount != 0 (${state3Middleware.duplicateCount})\n > ${state3Middleware.duplicates}" }
+    }
+
+    //
+    // composite store
+    //
+
+    @Test
+    fun `initial subscribe receives current state`() {
+        val subscriber = TestSubscriber<TestState>()
+        testStore.subscribe(subscriber)
+
+        assert(subscriber.receivedInitialState) { "subscriber.receivedInitialState != true" }
+        assert(subscriber.callCount == 0) { "subscriber.callCount != 0 (${subscriber.callCount})" }
+    }
+
+    @Test
+    fun `effect dispatched to composite store triggers composite store listener`() {
+        val listener = TestListener2<TestEffect>()
+        testStore.listen(listener)
+        testStore.dispatch(TestEffect)
+
+        assert(listener.callCount == 1) { "listener.callCount != 1 (${listener.callCount})" }
+    }
+
+    @Test
+    fun `action dispatched to composite store triggers composite store subscriber`() {
+        val subscriber = TestSubscriber<TestState>()
+        testStore.subscribe(subscriber)
+        testStore.dispatch(SetState1String("test"))
+
+        assert(subscriber.receivedInitialState) { "subscriber.receivedInitialState != true" }
+        assert(subscriber.callCount == 1) { "subscriber.callCount != 1 (${subscriber.callCount})" }
+    }
+
+    @Test
+    fun `actions dispatched to composite store updates relevant stores and calls relevant subscribers`() {
+        val subscriber1 = TestSubscriber<State1>()
+        val subscriber2 = TestSubscriber<State2>()
+        val subscriber3 = TestSubscriber<State3>()
+        val testSubscriber = TestSubscriber<TestState>()
+
+        store1.subscribe(subscriber1)
+        store2.subscribe(subscriber2)
+        store3.subscribe(subscriber3)
+        testStore.subscribe(testSubscriber)
+
+        testStore.dispatch(SetState1String(value = "new value!"))
+        assert(subscriber1.callCount == 1) { "subscriber1.callCount != 1 ${subscriber1.callCount}" }
+        assert(subscriber2.callCount == 0) { "subscriber2.callCount != 0 ${subscriber2.callCount}" }
+        assert(subscriber3.callCount == 0) { "subscriber3.callCount != 0 ${subscriber3.callCount}" }
+        assert(testSubscriber.callCount == 1) { "testSubscriber.callCount != 1 ${testSubscriber.callCount}" }
+        assert(subscriber1.lastState == testStore.state.state1) { "${subscriber1.lastState} != ${testStore.state.state1}" }
+
+        testStore.dispatch(SetState2Integer(value = 123))
+        assert(subscriber1.callCount == 1) { "subscriber1.callCount != 1 ${subscriber1.callCount}" }
+        assert(subscriber2.callCount == 1) { "subscriber2.callCount != 1 ${subscriber2.callCount}" }
+        assert(subscriber3.callCount == 0) { "subscriber3.callCount != 0 ${subscriber3.callCount}" }
+        assert(testSubscriber.callCount == 2) { "testSubscriber.callCount != 2 ${testSubscriber.callCount}" }
+        assert(subscriber2.lastState == testStore.state.state2) { "${subscriber2.lastState} != ${testStore.state.state2}" }
+
+        testStore.dispatch(SetState3Boolean(value = true))
+        assert(subscriber1.callCount == 1) { "subscriber1.callCount != 1 ${subscriber1.callCount}" }
+        assert(subscriber2.callCount == 1) { "subscriber2.callCount != 1 ${subscriber2.callCount}" }
+        assert(subscriber3.callCount == 1) { "subscriber3.callCount != 1 ${subscriber3.callCount}" }
+        assert(testSubscriber.callCount == 3) { "testSubscriber.callCount != 2 ${testSubscriber.callCount}" }
+        assert(subscriber3.lastState == testStore.state.state3) { "${subscriber3.lastState} != ${testStore.state.state3}" }
+    }
+
+    @Test
+    fun `effect dispatched to composite store triggers effect dispatch and triggers composite store listeners`() {
+        val listener1 = TestListener2<TestEffect>()
+        val listener2 = TestListener2<TestEffect2>()
+
+        testStore.listen(listener1)
+        testStore.listen(listener2)
+        store2.listenTo<TestEffect> { testStore.dispatch(TestEffect2) }
+
+        testStore.dispatch(TestEffect)
+
+        assert(listener1.callCount == 1) { "listener1.callCount != 1 (${listener1.callCount})" }
+        assert(listener2.callCount == 1) { "listener2.callCount != 1 (${listener2.callCount})" }
+    }
+
+    //
+    // composite store select
+    //
+
+    @Test
+    fun `subscribe with select and unsubscribe`() {
+        val subscriber = TestSubscriber<SelectState>()
+        testStore.subscribe(subscriber) {
+            select {
+                SelectState(
+                    state1.string,
+                    state2.integer,
+                    state3.boolean
+                )
+            }
+        }
+
+        testStore.dispatch(SetState1String(value = "new value!"))
+        assert(subscriber.callCount == 1) { "subscriber.callCount != 1 (${subscriber.callCount})" }
+
+        testStore.unsubscribe(subscriber)
+        testStore.dispatch(SetState1String(value = "another value!"))
+        assert(subscriber.callCount == 1) { "subscriber.callCount != 1 (${subscriber.callCount})" }
+
+        assert(testStore.state.state1 == store1.state)
+        assert(testStore.state.state2 == store2.state)
+        assert(testStore.state.state3 == store3.state)
+    }
+
+    @Test
+    fun `subscribe with select doesn't send duplicates`() {
+        val subscriber = TestSubscriber<SelectState>()
+        testStore.subscribe(subscriber) {
+            select {
+                SelectState(
+                    state1.string,
+                    state2.integer,
+                    state3.boolean
+                )
+            }
+        }
+
+        testStore.dispatch(SetState1String(value = "new value!"))
+        assert(subscriber.callCount == 1) { "subscriber.callCount != 1 (${subscriber.callCount})" }
+
+        testStore.dispatch(SetState1String(value = "new value!"))
+        testStore.dispatch(SetState1String2(value = "other string"))
+        assert(subscriber.callCount == 1) { "subscriber.callCount != 1 (${subscriber.callCount})" }
+    }
+
+    //
+    // composite store > store
+    //
+
+    @Test
+    fun `effect dispatched to store triggers composite store listener`() {
+        val listener = TestListener2<TestEffect>()
+        testStore.listen(listener)
+        store1.dispatch(TestEffect)
+
+        assert(listener.callCount == 1) { "listener.callCount != 1 (${listener.callCount})" }
+    }
+
+    @Test
+    fun `action dispatched to store triggers composite store subscriber`() {
+        val subscriber = TestSubscriber<TestState>()
+        testStore.subscribe(subscriber)
+        store1.dispatch(SetState1String(value = "test"))
+
+        assert(subscriber.callCount == 1) { "subscriber.callCount != 1 (${subscriber.callCount})" }
+    }
+
+    @Test
+    fun `unrelated action dispatched to store does not trigger composite store subscriber`() {
+        val subscriber = TestSubscriber<TestState>()
+        testStore.subscribe(subscriber)
+        store1.dispatch(SetState2Integer(value = 123))
+
+        assert(subscriber.callCount == 0) { "subscriber.callCount != 0 (${subscriber.callCount})" }
+    }
+
+    //
+    // store > composite store
+    //
+
+    @Test
+    fun `effect dispatched to composite store triggers store listener`() {
+        val listener = TestListener2<TestEffect>()
+        store1.listen(listener)
+        testStore.dispatch(TestEffect)
+
+        assert(listener.callCount == 1) { "listener.callCount != 1 (${listener.callCount})" }
+    }
+
+    @Test
+    fun `action dispatched to composite store triggers store subscriber`() {
+        val subscriber = TestSubscriber<State1>()
+        store1.subscribe(subscriber)
+        testStore.dispatch(SetState1String(value = "test"))
+
+        assert(subscriber.callCount == 1) { "subscriber.callCount != 1 (${subscriber.callCount})" }
+    }
+
+    @Test
+    fun `unrelated action dispatched to composite store does not trigger store subscriber`() {
+        val subscriber = TestSubscriber<State1>()
+        store1.subscribe(subscriber)
+        testStore.dispatch(SetState2Integer(value = 123))
+
+        assert(subscriber.callCount == 0) { "subscriber.callCount != 0 (${subscriber.callCount})" }
+    }
+
+    //
+    // store > store
+    //
+
+    @Test
+    fun `effect dispatched to store does not trigger other store listener`() {
+        val listener = TestListener2<TestEffect>()
+        store2.listen(listener)
+        store1.dispatch(TestEffect)
+
+        assert(listener.callCount == 0) { "listener.callCount != 0 (${listener.callCount})" }
+    }
+
+    @Test
+    fun `action dispatched to store does not trigger other store subscriber`() {
+        val subscriber = TestSubscriber<State2>()
+        store2.subscribe(subscriber)
+        store1.dispatch(SetState1String(value = "test"))
+
+        assert(subscriber.callCount == 0) { "subscriber.callCount != 0 (${subscriber.callCount})" }
+    }
+
+    @Test
+    fun `unrelated action dispatched to store does not trigger other store subscriber`() {
+        val subscriber = TestSubscriber<State2>()
+        store2.subscribe(subscriber)
+        store1.dispatch(SetState2Integer(value = 123))
+
+        assert(subscriber.callCount == 0) { "subscriber.callCount != 0 (${subscriber.callCount})" }
+    }
+
+    //
+    // composite store (1) > composite store (2)
+    //
+
+    @Test
+    fun `effect dispatched to composite store triggers other composite store listener`() {
+        val listener = TestListener2<TestEffect>()
+        testStore12.listen(listener)
+        testStore23.dispatch(TestEffect)
+
+        assert(listener.callCount == 1) { "listener.callCount != 1 (${listener.callCount})" }
+    }
+
+    @Test
+    fun `action dispatched to composite store triggers other composite store subscriber`() {
+        val subscriber = TestSubscriber<TestState12>()
+        testStore12.subscribe(subscriber)
+        testStore23.dispatch(SetState2Integer(value = 123))
+
+        assert(subscriber.callCount == 1) { "subscriber.callCount != 1 (${subscriber.callCount})" }
+    }
+
+    @Test
+    fun `unrelated action dispatched to composite store does not trigger other composite store subscriber`() {
+        val subscriber = TestSubscriber<TestState12>()
+        testStore12.subscribe(subscriber)
+        testStore23.dispatch(SetState3Boolean(value = true))
+
+        assert(subscriber.callCount == 0) { "subscriber.callCount != 0 (${subscriber.callCount})" }
+    }
+
+    //
+    // middleware
+    //
+
+    @Test
+    fun `cross composite store calls middleware once for duplicate stores`() {
+        data class TestState23And12(
+            val state2: State2,
+            val state3: State3,
+            val state1: State1
+        )
+
+        val testStore23And12 = composeStores(
+            store2,
+            store3,
+            testStore12,
+            thunkMiddleware()
+        ) { a, b, c ->
+            TestState23And12(
+                state2 = a,
+                state3 = b,
+                state1 = c.state1
+            )
+        }
+
+        val subscriber = TestSubscriber<State2>()
+        store2.subscribe(subscriber)
+
+        testStore23And12.dispatch(SetState2Integer(value = 123))
+
+        assert(subscriber.callCount == 1) { "subscriber.callCount != 1 (${subscriber.callCount})" }
+    }
+
+    @Test
+    fun `cross composite store calls middleware once for duplicate stores2`() {
+        data class State13(
+            val state1: State1,
+            val state3: State3
+        )
+
+        val testStore13 = composeStores(
+            store1,
+            store3,
+            thunkMiddleware()
+        ) { a, b ->
+            State13(
+                state1 = a,
+                state3 = b
+            )
+        }
+
+        data class TestState2And3And13And123(
+            val state2: State2,
+            val state3: State3,
+            val state13: State13,
+            val testState: TestState
+        )
+
+        val testStore2And3And13And123 = composeStores(
+            store2,
+            store3,
+            testStore,
+            testStore13,
+            thunkMiddleware()
+        ) { a, b, c, d ->
+            TestState2And3And13And123(
+                state2 = a,
+                state3 = b,
+                state13 = d,
+                testState = c
+            )
+        }
+
+        val subscriber = TestSubscriber<State3>()
+        store3.subscribe(subscriber)
+
+        testStore2And3And13And123.dispatch(SetState3Boolean(value = true))
+
+        assert(subscriber.callCount == 1) { "subscriber.callCount != 1 (${subscriber.callCount})" }
+    }
+
+    //
+    // middleware (thunk)
+    //
+
+    @Test
+    fun `thunk dispatched to composite store affects relevant stores`() {
+        val store3Subscriber = TestSubscriber<State3> {
+            println("Got $it")
+            if (it.boolean == null) {
+                store3.dispatch(SetState3Boolean(value = true))
+            }
+        }
+        store3.subscribe(store3Subscriber)
+
+        val store2Thunk1 = testThunk<State2> { _, _ ->
+            testStore.dispatch(SetState3Boolean(value = null))
+        }
+        val store2Thunk2 = testThunk<State2> { _, _ ->
+            testStore.dispatch(SetState3Boolean(value = null))
+        }
+
+        val testStoreThunk = testThunk<TestState> { _, _ ->
+            store2.dispatch(store2Thunk1)
+        }
+        val store1Thunk = testThunk<State1> { _, _ ->
+            store2.dispatch(store2Thunk2)
+        }
+
+        testStore.dispatch(testStoreThunk)
+        assert(testStoreThunk.callCount == 1) { "testStoreThunk.callCount != 1 (${testStoreThunk.callCount})" }
+        assert(store2Thunk1.callCount == 1) { "store2Thunk1.callCount != 1 (${store2Thunk1.callCount})" }
+
+        store1.dispatch(store1Thunk)
+        assert(store1Thunk.callCount == 1) { "store1Thunk.callCount != 1 (${store1Thunk.callCount})" }
+        assert(store2Thunk2.callCount == 1) { "store2Thunk2.callCount != 1 (${store2Thunk2.callCount})" }
+
+        // false(init) -> null -> true -> null -> true
+        val actual = store3Subscriber.history.map { it.boolean }
+        val expectedHistory = listOf(false, null, true, null, true)
+        assert(actual == expectedHistory) { "store3Subscriber.history != expectedHistory ($actual != $expectedHistory)" }
+        assert(store3.state.boolean == true) { "store3.state.boolean != null (${store3.state.boolean})" }
+    }
+
+    @Test
+    fun `thunk dispatched to composite store then thunk dispatch affects relevant store`() {
+        val store3Subscriber = TestSubscriber<State3> {
+            if (it.boolean == null) {
+                store3.dispatch(SetState3Boolean(value = true))
+            }
+        }
+        store3.subscribe(store3Subscriber)
+
+        val thunk = testThunk<TestState> { dispatch, _ ->
+            dispatch(SetState1String("Loading..."))
+            dispatch(SetState3Boolean(value = null))
+        }
+
+        println("\n=== testStore.dispatch(store1Thunk) ===")
+        testStore.dispatch(thunk)
+        assert(store3.state.boolean == true) { "store3.state.boolean != true (${store3.state.boolean})" }
+    }
+
+    @Test
+    fun `thunk dispatched to composite store triggers other composite store listener`() {
+        val initialValue = testStore23.state.state2.integer
+        val add = 10
+
+        val store23Thunk = testThunk<TestState23> { dispatch, getState ->
+            dispatch(SetState2Integer(value = (getState()?.state2?.integer ?: -1) + add))
+        }
+
+        val subscriber = TestSubscriber<TestState12>()
+        testStore12.subscribe(subscriber)
+        testStore23.dispatch(store23Thunk)
+
+        assert(subscriber.callCount == 1) { "subscriber.callCount != 1 (${subscriber.callCount})" }
+        assert(store2.state.integer == initialValue + add) { "store2.state.integer != initialValue+add (${store2.state.integer})" }
+    }
+}
+
+private class TestSubscriber<S>(private val block: (S) -> Unit = {}) : Subscriber<S> {
+    var receivedInitialState: Boolean = false
+        private set
+    val lastState: S?
+        get() = _history.lastOrNull()
+    val callCount
+        get() = _history.size - 1
+    val history: List<S>
+        get() = _history
+
+    private val _history: MutableList<S> = mutableListOf()
+
+    override fun newState(state: S) {
+        if (_history.isEmpty()) {
+            receivedInitialState = true
+        }
+
+        _history.add(state)
+        block(state)
+    }
+}
+
+private inline fun <reified EffectType : Effect> SubscribeStore<*>.listen(listener: Listener<EffectType>) =
+    subscribe(listener) { it as? EffectType }
+
+private class TestListener2<E>(private val block: (E) -> Unit = {}) : Listener<E> {
+    val callCount
+        get() = _history.size
+
+    private val _history: MutableList<E> = mutableListOf()
+
+    override fun onEffect(effect: E) {
+        _history.add(effect)
+        block(effect)
+    }
+}
+
+private fun <S : Any> testThunk(
+    block: ((DispatchFunction, () -> S?) -> Unit)? = null
+) = TestThunk(block)
+
+private class TestThunk<S : Any>(private val block: ((DispatchFunction, () -> S?) -> Unit)? = null) : Thunk<S> {
+    var callCount = 0
+        private set
+
+    override fun invoke(dispatch: DispatchFunction, getState: () -> S?) {
+        callCount++
+        block?.invoke(dispatch, getState)
+    }
+}
+
+private fun <S> testMiddleware(
+    next: (action: Dispatchable, getState: () -> S?) -> Unit
+) = TestMiddleware(next)
+
+private class TestMiddleware<S>(
+    private val next: (action: Dispatchable, getState: () -> S?) -> Unit
+) : Middleware<S> {
+    private val dispatchableHistory = IdentityHashMap<Dispatchable, Int>()
+
+    var callCount = 0
+    val duplicates get() = dispatchableHistory.filter { it.value != 1 }
+    val duplicateCount get() = duplicates.size
+
+    override fun invoke(dispatch: DispatchFunction, getState: () -> S?): (DispatchFunction) -> DispatchFunction = { next ->
+            { action ->
+                callCount++
+                dispatchableHistory[action] = (dispatchableHistory[action] ?: 0) + 1
+
+                this.next(action, getState)
+                next(action)
+            }
+        }
+}

--- a/rekotlin/src/test/kotlin/org/rekotlin/CompositeStoreTests.kt
+++ b/rekotlin/src/test/kotlin/org/rekotlin/CompositeStoreTests.kt
@@ -4,10 +4,10 @@ import java.util.IdentityHashMap
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
-//<editor-fold desc="State 1">
+// <editor-fold desc="State 1">
 private data class State1(
-        val string: String = "",
-        val string2: String = ""
+    val string: String = "",
+    val string2: String = ""
 )
 
 private data class SetState1String(val value: String) : Action
@@ -22,11 +22,11 @@ private fun state1Reducer(action: Action, oldState: State1?): State1 {
     }
 }
 
-//</editor-fold>
+// </editor-fold>
 
-//<editor-fold desc="State 2">
+// <editor-fold desc="State 2">
 private data class State2(
-        val integer: Int = 0
+    val integer: Int = 0
 )
 
 private fun state2Reducer(action: Action, oldState: State2?): State2 {
@@ -38,11 +38,11 @@ private fun state2Reducer(action: Action, oldState: State2?): State2 {
 }
 
 private data class SetState2Integer(val value: Int) : Action
-//</editor-fold>
+// </editor-fold>
 
-//<editor-fold desc="State 3">
+// <editor-fold desc="State 3">
 private data class State3(
-        val boolean: Boolean? = false
+    val boolean: Boolean? = false
 )
 
 private fun state3Reducer(action: Action, oldState: State3?): State3 {
@@ -54,8 +54,7 @@ private fun state3Reducer(action: Action, oldState: State3?): State3 {
 }
 
 private data class SetState3Boolean(val value: Boolean?) : Action
-//</editor-fold>
-
+// </editor-fold>
 
 class CompositeStoreTests {
 
@@ -91,7 +90,7 @@ class CompositeStoreTests {
         assert(state3Middleware.duplicateCount == 0) { "state3Middleware.duplicateCount != 0 (${state3Middleware.duplicateCount})\n > ${state3Middleware.duplicates}" }
     }
 
-    //<editor-fold desc="composite store">
+    // <editor-fold desc="composite store">
     @Test
     fun `should receive current state on subscribe`() {
         val subscriber = TestSubscriber<CompositeState>()
@@ -125,9 +124,9 @@ class CompositeStoreTests {
     fun `should notify all stores on dispatch action to composite store`() {
         compositeStore.dispatch(SetState2Integer(value = 123))
 
-        assert(state1Middleware.callCount == 1) {"state1Middleware.callCount != 1 ${state1Middleware.callCount}"}
-        assert(state2Middleware.callCount == 1) {"state2Middleware.callCount != 1 ${state2Middleware.callCount}"}
-        assert(state3Middleware.callCount == 1) {"state3Middleware.callCount != 1 ${state3Middleware.callCount}"}
+        assert(state1Middleware.callCount == 1) { "state1Middleware.callCount != 1 ${state1Middleware.callCount}" }
+        assert(state2Middleware.callCount == 1) { "state2Middleware.callCount != 1 ${state2Middleware.callCount}" }
+        assert(state3Middleware.callCount == 1) { "state3Middleware.callCount != 1 ${state3Middleware.callCount}" }
     }
 
     @Test
@@ -182,7 +181,6 @@ class CompositeStoreTests {
         assert(subscriber2.callCount == 0) { "subscriber2.callCount != 1 ${subscriber2.callCount}" }
     }
 
-
     @Test
     fun `composite store should always notify its own subscribers when an a store's state changes`() {
         val testSubscriber = TestSubscriber<CompositeState>().also {
@@ -198,14 +196,14 @@ class CompositeStoreTests {
         compositeStore.dispatch(SetState3Boolean(true))
         assert(testSubscriber.callCount == 3) { "testSubscriber.callCount != 2 ${testSubscriber.callCount}" }
     }
-    //</editor-fold>
+    // </editor-fold>
 
-    //<editor-fold desc="composite store select">
+    // <editor-fold desc="composite store select">
 
     data class SelectState(
-            val string: String,
-            val int: Int,
-            val bool: Boolean?
+        val string: String,
+        val int: Int,
+        val bool: Boolean?
     )
 
     @Test
@@ -253,9 +251,9 @@ class CompositeStoreTests {
         compositeStore.dispatch(SetState1String2(value = "other string"))
         assert(subscriber.callCount == 1) { "subscriber.callCount != 1 (${subscriber.callCount})" }
     }
-    //</editor-fold>
+    // </editor-fold>
 
-    //<editor-fold desc="Effects & Actions dispatched to store > composite store">
+    // <editor-fold desc="Effects & Actions dispatched to store > composite store">
     @Test
     fun `effect dispatched to store triggers composite store listener`() {
         val listener = CountingListener<TestEffect>().also { compositeStore.listen(it) }
@@ -282,9 +280,9 @@ class CompositeStoreTests {
 
         assert(subscriber.callCount == 0) { "subscriber.callCount != 0 (${subscriber.callCount})" }
     }
-    //</editor-fold>
+    // </editor-fold>
 
-    //<editor-fold desc="Effects & Actions dispatched to composite store > store">
+    // <editor-fold desc="Effects & Actions dispatched to composite store > store">
     @Test
     fun `effect dispatched to composite store triggers store listener`() {
         val listener1 = CountingListener<TestEffect>().also { store1.listen(it) }
@@ -311,9 +309,9 @@ class CompositeStoreTests {
 
         assert(subscriber1.callCount == 0) { "subscriber.callCount != 0 (${subscriber1.callCount})" }
     }
-    //</editor-fold>
+    // </editor-fold>
 
-    //<editor-fold desc="Effects & Actions dispatched to store > store">
+    // <editor-fold desc="Effects & Actions dispatched to store > store">
     @Test
     fun `effect dispatched to store does not trigger other store listener`() {
         val listener = CountingListener<TestEffect>().also { store2.listen(it) }
@@ -340,12 +338,12 @@ class CompositeStoreTests {
 
         assert(subscriber.callCount == 0) { "subscriber.callCount != 0 (${subscriber.callCount})" }
     }
-    //</editor-fold>
+    // </editor-fold>
 
-    //<editor-fold desc="more composite stores">
+    // <editor-fold desc="more composite stores">
     private data class TestState12(
-            val state1: State1,
-            val state2: State2
+        val state1: State1,
+        val state2: State2
     )
 
     private val compositeStore12 = composeStores(store1, store2, LoggingMiddleware("store 12"), thunkMiddleware()) { a, b ->
@@ -356,8 +354,8 @@ class CompositeStoreTests {
     }
 
     private data class TestState23(
-            val state2: State2,
-            val state3: State3
+        val state2: State2,
+        val state3: State3
     )
     private val compositeStore23 = composeStores(store2, store3, LoggingMiddleware("store 23"), thunkMiddleware()) { a, b ->
         TestState23(
@@ -365,9 +363,9 @@ class CompositeStoreTests {
                 state3 = b
         )
     }
-    //</editor-fold>
+    // </editor-fold>
 
-    //<editor-fold desc="composite store (12) > composite store (23)">
+    // <editor-fold desc="composite store (12) > composite store (23)">
     @Test
     fun `effect dispatched to composite store triggers other composite store listener`() {
         val listener12 = CountingListener<TestEffect>().also { compositeStore12.listen(it) }
@@ -394,9 +392,9 @@ class CompositeStoreTests {
 
         assert(subscriber12.callCount == 0) { "subscriber.callCount != 0 (${subscriber12.callCount})" }
     }
-    //</editor-fold>
+    // </editor-fold>
 
-    //<editor-fold desc="middleware">
+    // <editor-fold desc="middleware">
     @Test
     fun `cross composite store calls middleware once for duplicate stores`() {
         data class TestState23And12(
@@ -474,9 +472,9 @@ class CompositeStoreTests {
 
         assert(subscriber.callCount == 1) { "subscriber.callCount != 1 (${subscriber.callCount})" }
     }
-    //</editor-fold>
+    // </editor-fold>
 
-    //<editor-fold desc="thunk middleware">
+    // <editor-fold desc="thunk middleware">
     @Test
     fun `thunk dispatched to composite store affects relevant stores`() {
         val store3Subscriber = TestSubscriber<State3> {
@@ -551,7 +549,7 @@ class CompositeStoreTests {
         assert(subscriber.callCount == 1) { "subscriber.callCount != 1 (${subscriber.callCount})" }
         assert(store2.state.integer == initialValue + add) { "store2.state.integer != initialValue+add (${store2.state.integer})" }
     }
-    //</editor-fold>
+    // </editor-fold>
 }
 
 private class TestSubscriber<S>(private val block: (S) -> Unit = {}) : Subscriber<S> {
@@ -602,15 +600,13 @@ private class TestThunk<S : Any>(private val block: ((DispatchFunction, () -> S?
     }
 }
 
-private class LoggingMiddleware<S>(private val label: String): Middleware<S> {
-    override fun invoke(dispatch: DispatchFunction, getState: () -> S?): (DispatchFunction) -> DispatchFunction =
-            { next ->
-                {   action ->
+private class LoggingMiddleware<S>(private val label: String) : Middleware<S> {
+    override fun invoke(dispatch: DispatchFunction, getState: () -> S?): (DispatchFunction) -> DispatchFunction = { next ->
+                { action ->
                     println(">> $label ($action, ${getState()})")
                     next(action)
                 }
             }
-
 }
 
 private class CountingMiddleware<S> : Middleware<S> {

--- a/rekotlin/src/test/kotlin/org/rekotlin/EffectTests.kt
+++ b/rekotlin/src/test/kotlin/org/rekotlin/EffectTests.kt
@@ -34,11 +34,11 @@ fun reducer(action: Action, state: AppState?) = state ?: AppState
 object TestEffect : Effect
 object TestEffect2 : Effect
 
-class TestListener<E : Effect>(private val block: (E) -> Unit) : Listener<E> {
+private class TestListener<E : Effect>(private val block: (E) -> Unit) : Listener<E> {
     override fun onEffect(effect: E) = block(effect)
 }
 
-class SimpleSubscriber<S>(private val block: (S) -> Unit) : Subscriber<S> {
+private class SimpleSubscriber<S>(private val block: (S) -> Unit) : Subscriber<S> {
     override fun newState(state: S) = block(state)
 }
 


### PR DESCRIPTION
Used in modularization PoC at https://github.com/Rakuten-MTSD-PAIS/mavenir-android-client-snapshot/pull/3059

- Allows a module to have its own store, state, and middleware.
- In turn allows other modules (which also have their own store, state, and middleware) to create a "composite" store of two or more stores from other modules (including composites of composites).
- The composite store implements and behaves like a normal `Store`
  - In the PoC above, this means that the rest of the code does not need to change because it still acts and behaves as a normal `Store` (only the declaration of the stores changes)

The behavior of the composite store ensures that all related stores are appropriately updated etc no matter which module triggers a store state change. The tests show the full relations/behavior between stores, but in summary;

- Any `Effect` dispatched to `ModuleStore` will trigger any listeners on their `ModuleStore` or any `CompositeStore` that includes `ModuleStore`
- And vice versa - an `Effect` dispatched to `CompositeStore` will dispatch to its included stores
- Any `Action` dispatched to the `ModuleStore` will trigger `CompositeStore` subscribers
- And vice versa - an `Action` dispatched to the `CompositeStore` is dispatched to all included stores (and triggers subscribers in other composite stores appropriately as states change etc.)

Because each module has its own store and state type, it can also use `thunk` middleware internally (not possible with child stores). So in the PoC above it allows having a "navigation" module that handles the router state. Its store can declare and use its own middleware to manipulate the navigation state without exposing its middleware or other internals to the rest of the app.
