### PR TITLE
Prevent crash due to simultaneous pushroute action

### DIFF
--- a/rekotlin-router/build.gradle
+++ b/rekotlin-router/build.gradle
@@ -3,5 +3,5 @@ dependencies {
 
     testImplementation project(':rekotlin')
     testImplementation 'org.mockito:mockito-core:2.28.2'
-    testImplementation 'org.amshove.kluent:kluent-android:1.49'
+    testImplementation 'org.amshove.kluent:kluent-android:1.68'
 }

--- a/rekotlin-router/gradle.properties
+++ b/rekotlin-router/gradle.properties
@@ -1,2 +1,2 @@
-version = 1.0.0
+version = 1.0.1
 description = Routing on top of ReKotlin

--- a/rekotlin-router/src/main/kotlin/org/rekotlin/router/Router.kt
+++ b/rekotlin-router/src/main/kotlin/org/rekotlin/router/Router.kt
@@ -75,7 +75,10 @@ internal class Router(
             when (action) {
                 is Pop -> uiThreadHandler {
                     routables[action.routableIndex].popRouteSegment(action.segmentToPop, state.animated)
-                    routables.removeAt(action.routableIndex + 1)
+                    val itemIndex = action.routableIndex + 1
+                    if (itemIndex < routables.size) {
+                        routables.removeAt(itemIndex)
+                    }
                 }
 
                 is Push -> uiThreadHandler {

--- a/rekotlin-router/src/test/kotlin/org/rekotlin/router/RouterIntegerationSpec.kt
+++ b/rekotlin-router/src/test/kotlin/org/rekotlin/router/RouterIntegerationSpec.kt
@@ -1,6 +1,9 @@
 package org.rekotlin.router
 
-import org.amshove.kluent.*
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldEqual
+import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.rekotlin.Action
@@ -118,7 +121,7 @@ class RoutingCallTests {
         store.dispatch(newRouteAction) // moving to different route segment under the same common-sub-route(root)
 
         // Then
-        isPopCalled shouldBeEqualTo true
+        isPopCalled.shouldBeTrue()
     }
 }
 

--- a/rekotlin-router/src/test/kotlin/org/rekotlin/router/RouterIntegerationSpec.kt
+++ b/rekotlin-router/src/test/kotlin/org/rekotlin/router/RouterIntegerationSpec.kt
@@ -1,9 +1,6 @@
 package org.rekotlin.router
 
-import org.amshove.kluent.shouldBeFalse
-import org.amshove.kluent.shouldBeTrue
-import org.amshove.kluent.shouldEqual
-import org.amshove.kluent.shouldNotBeNull
+import org.amshove.kluent.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.rekotlin.Action
@@ -100,6 +97,28 @@ class RoutingCallTests {
         // Then
         rootSegment shouldHaveId "root"
         childSegment shouldHaveId "child"
+    }
+
+    @Test
+    fun `should pop route segment when different route is dispatched with common sub-route`() {
+
+        // Given
+        val oldRouteAction = SetRouteAction(Route("root", "child", "sub-child"))
+        val newRouteAction = SetRouteAction(Route("root", "new-child", "sub-child-new"))
+        var isPopCalled = false
+        val root = FakeRoutable(
+            // push = { segment, _ -> childSegment = segment },
+            pop = { segment, _ -> isPopCalled = true }
+        )
+        store.dispatch(oldRouteAction) // dispatching initial navigation state.
+        val router = router(root)
+        store.subscribe(router) { select { navigationState } }
+
+        // When
+        store.dispatch(newRouteAction) // moving to different route segment under the same common-sub-route(root)
+
+        // Then
+        isPopCalled shouldBeEqualTo true
     }
 }
 


### PR DESCRIPTION
The crash was caused by an IndexOutOfBoundsException at the line routables.removeAt(itemIndex). This happened when performing two PushRouteAction actions simultaneously. In such cases, the routables list was not updated in time, leading to a situation where itemIndex was greater than or equal to the size of the routables list.

To fix this issue, we added a check to ensure that itemIndex is within the valid range of indices for the routables list before calling removeAt(itemIndex). Specifically, we check if itemIndex is less than the size of the list. This ensures that we only attempt to remove an item if itemIndex is within bounds, thereby preventing the IndexOutOfBoundsException.

By adding this check, we ensure that the code handles the case where the list might not be updated in time due to simultaneous PushRouteAction actions, thus maintaining the stability and correctness of the navigation state management.